### PR TITLE
feat(Add footer, imprint and data protection page #181): add basic footer

### DIFF
--- a/apps/nextjs-frontend/src/app/layout.tsx
+++ b/apps/nextjs-frontend/src/app/layout.tsx
@@ -10,6 +10,7 @@ import {ReactQueryProvider} from '@/providers/react-query/react-query.provider';
 import {ToastProvider} from '@/providers/toast/toast.provider';
 import {UserProvider} from '@/providers/user/user.provider';
 import {Header} from '@/components/header/header.component.tsx';
+import {Footer} from '@/components/footer/footer.component';
 
 export const metadata: Metadata = {
   title: 'Next.js Frontend',
@@ -29,9 +30,10 @@ export default function RootLayout({
           <UserProvider>
             <ReactQueryProvider>
               <Header />
-              <div className="mx-auto my-6 flex w-full max-w-7xl flex-col px-2 md:my-8 md:px-4 lg:my-12">
+              <div className="mx-auto my-6 flex w-full max-w-7xl flex-col px-2 md:my-8 md:px-4 lg:my-12 min-h-screen">
                 {children}
               </div>
+              <Footer />
             </ReactQueryProvider>
           </UserProvider>
         </ToastProvider>

--- a/apps/nextjs-frontend/src/components/footer/footer.component.tsx
+++ b/apps/nextjs-frontend/src/components/footer/footer.component.tsx
@@ -1,0 +1,64 @@
+import Link from 'next/link';
+import {type JSX, useMemo} from 'react';
+
+type FooterItem = {
+  label: string;
+  href: string;
+};
+
+type FooterItemsGroup = {
+  label: string;
+  items: FooterItem[];
+};
+
+export function Footer(): JSX.Element {
+  const footerItemsGroups: FooterItemsGroup[] = useMemo(
+    () => [
+      {
+        label: 'Company',
+        items: [
+          {label: 'About Us', href: '/about'},
+          {label: 'Contact', href: '/contact'},
+        ],
+      },
+      {
+        label: 'Support',
+        items: [
+          {label: 'Imprint', href: '/imprint'},
+          {label: 'Privacy Policy', href: '/privacy'},
+          {label: 'Terms of Service', href: '/terms'},
+        ],
+      },
+    ],
+    [],
+  );
+
+  return (
+    <footer className="px-2 md:px-4 py-4 bg-gray-200 text-gray-700 max-w-full">
+      <div className="mx-auto max-w-7xl text-center divide-y-1 divide-gray-300">
+        <nav className="mb-4 pb-4">
+          <ul className="flex flex-wrap justify-center gap-8 md:gap-12 lg:gap-16">
+            {footerItemsGroups.map((group) => (
+              <li key={group.label} className="mb-2 text-sm">
+                <p className="tracking-widest text-gray-400 mb-1">{group.label}</p>
+                <ul>
+                  {group.items.map((item) => (
+                    <li key={item.label}>
+                      <Link
+                        href={item.href}
+                        className="text-gray-600 hover:text-gray-800 transition-colors duration-200"
+                      >
+                        {item.label}
+                      </Link>
+                    </li>
+                  ))}
+                </ul>
+              </li>
+            ))}
+          </ul>
+        </nav>
+        <p className="text-sm text-gray-400">&copy; {new Date().getFullYear()} My Company. All rights reserved.</p>
+      </div>
+    </footer>
+  );
+}

--- a/apps/nextjs-frontend/src/components/header/header.component.tsx
+++ b/apps/nextjs-frontend/src/components/header/header.component.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import {useRef, type JSX} from 'react';
+import {useMemo, useRef, type JSX} from 'react';
 import Link from 'next/link';
 import {useRouter} from 'next/navigation';
 import {Button} from 'primereact/button';
@@ -19,32 +19,35 @@ export function Header(): JSX.Element {
 
   const {logout} = useAuthApi();
 
-  const items: MenuItem[] = [];
+  const items: MenuItem[] = useMemo(() => [], []);
 
-  const endMenuItems: MenuItem[] = [
-    {
-      label: `Hey, ${user?.username ?? 'User'}`,
-      items: [
-        {
-          label: 'Profile',
-          icon: 'pi pi-cog',
-          command(): void {
-            router.push('/profile');
+  const endMenuItems: MenuItem[] = useMemo(
+    () => [
+      {
+        label: `Hey, ${user?.username ?? 'User'}`,
+        items: [
+          {
+            label: 'Profile',
+            icon: 'pi pi-cog',
+            command(): void {
+              router.push('/profile');
+            },
           },
-        },
-        {
-          label: 'Logout',
-          icon: 'pi pi-sign-out',
-          command: async (): Promise<void> =>
-            logout({
-              onSuccess() {
-                router.push('/login');
-              },
-            }),
-        },
-      ],
-    },
-  ];
+          {
+            label: 'Logout',
+            icon: 'pi pi-sign-out',
+            command: async (): Promise<void> =>
+              logout({
+                onSuccess() {
+                  router.push('/login');
+                },
+              }),
+          },
+        ],
+      },
+    ],
+    [logout, router, user?.username],
+  );
 
   const signedInItem: JSX.Element = (
     <div className="flex gap-2">


### PR DESCRIPTION
This pull request introduces a new `Footer` component to the Next.js frontend application and integrates it into the layout. It also includes performance optimizations in the `Header` component by replacing static arrays with `useMemo` for memoization. Below are the key changes grouped by theme:

### New Footer Component
* Added a new `Footer` component in `apps/nextjs-frontend/src/components/footer/footer.component.tsx`. The footer includes navigation links grouped into categories (e.g., "Company" and "Support") and a copyright notice.
* Integrated the `Footer` component into the `RootLayout` in `apps/nextjs-frontend/src/app/layout.tsx`, ensuring it is displayed at the bottom of every page. The layout was also updated to include `min-h-screen` for proper footer positioning.

### Header Component Optimizations
* Updated the `Header` component to use `useMemo` for memoizing `items` and `endMenuItems`, improving performance by avoiding unnecessary recalculations.